### PR TITLE
Add thumbnail support for URLS with timestamps

### DIFF
--- a/maubot.yaml
+++ b/maubot.yaml
@@ -9,7 +9,7 @@ maubot: 0.1.0
 id: me.gogel.maubot.youtubepreview
 
 # A PEP 440 compliant version string.
-version: 0.0.1
+version: 0.0.2
 
 # The SPDX license identifier for the plugin. https://spdx.org/licenses/
 # Optional, assumes all rights reserved if omitted.

--- a/youtubepreview.py
+++ b/youtubepreview.py
@@ -35,7 +35,8 @@ class YoutubePreviewPlugin(Plugin):
                 video_id = url.split("youtu.be/")[1]
             else:
                 video_id = urllib.parse.parse_qs(urllib.parse.urlparse(url).query)['v'][0]
-            
+            video_id = video_id.split("?", 1)[0]
+
             params = {"format": "json", "url": url}
             query_url = "https://www.youtube.com/oembed"
             query_string = urllib.parse.urlencode(params)


### PR DESCRIPTION
URLS with a query string (e.g. timecodes) would prevent the script from getting the thumbnail. Adding a stringsplit to the videoID fixes this.