### PR TITLE
add music. prefix to music.youtube.com links

### DIFF
--- a/maubot.yaml
+++ b/maubot.yaml
@@ -9,7 +9,7 @@ maubot: 0.1.0
 id: me.gogel.maubot.youtubepreview
 
 # A PEP 440 compliant version string.
-version: 0.0.4
+version: 0.0.5
 
 # The SPDX license identifier for the plugin. https://spdx.org/licenses/
 # Optional, assumes all rights reserved if omitted.

--- a/youtubepreview.py
+++ b/youtubepreview.py
@@ -37,7 +37,7 @@ class YoutubePreviewPlugin(Plugin):
                 if "music." in subdomain:
                     music_prefix = "music."
                 else:
-                     music_prefix = ""
+                    music_prefix = ""
             
             if "youtu.be" in url:
                 video_id = url.split("youtu.be/")[1]

--- a/youtubepreview.py
+++ b/youtubepreview.py
@@ -14,6 +14,7 @@ class Config(BaseProxyConfig):
 
 
 youtube_pattern = re.compile(r".*((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?.*")
+music_pattern = re.compile(r".*((?:https?:)?\/\/)?((?:music|www|m)\.)((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)([\w\-]+)(\S+)?.*")
 
 class YoutubePreviewPlugin(Plugin):
     async def start(self) -> None:
@@ -31,6 +32,13 @@ class YoutubePreviewPlugin(Plugin):
             await evt.mark_read()
 
             url = ''.join(url_tup)
+
+            for subdomain in music_pattern.findall(evt.content.body):
+                if "music." in subdomain:
+                    music_prefix = "music."
+                else:
+                     music_prefix = ""
+            
             if "youtu.be" in url:
                 video_id = url.split("youtu.be/")[1]
             else:
@@ -47,7 +55,7 @@ class YoutubePreviewPlugin(Plugin):
                 return None
             response_text = response.read()
             data = json.loads(response_text.decode())
-            msg = data['title'] + ": " + url
+            msg = data['title'] + ": " + music_prefix + url
             await evt.respond(msg)
 
             thumbnail_link = "https://img.youtube.com/vi/" + video_id + "/hqdefault.jpg"


### PR DESCRIPTION
Sorry for another PR but this is my take to add the prefix `music.` to `music.youtube.com` links, if you have a better idea please let me know or feel free to make changes.

Will look like that:
![grafik](https://github.com/ggogel/YoutubePreviewMaubot/assets/28066518/57d31a48-8b80-426d-9e5d-c6fc7dea4e3e)
